### PR TITLE
Update template.yml to include copernicus.cfg

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -149,6 +149,7 @@ files:
   - template.tex
   - copernicus.bst
   - copernicus.cls
+  - copernicus.cfg
   - pdfscreen.sty
   - pdfscreencop.sty
 packages:


### PR DESCRIPTION
I might have found a bug with myst build file.md --pdf  when using the corpernicus EGU style. The log from the latex compile says,
```
./copernicus.cls:106: Class copernicus Error: No additional configuration file 
copernicus.cfg.
```
I have added `copernicus.cfg`to the template YAML file. This might fix the error messages on the build of the pdf.
